### PR TITLE
OMWAPPI-1819 correct key deserialization

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,6 +7,8 @@ BBFILES += "${LAYERDIR}/recipes-*/thunderclientlibraries/*.bb ${LAYERDIR}/recipe
 BBFILES += "${LAYERDIR}/recipes-core/packagegroups/*.bb"
 BBFILES += "${LAYERDIR}/recipes-core/images/*.bbappend"
 
+BBFILES += "${LAYERDIR}/recipes-netflix/netflix/*.bbappend"
+
 BBFILE_COLLECTIONS += "meta-thunder-rdkservices"
 BBFILE_PATTERN_meta-thunder-rdkservices := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-thunder-rdkservices = "102"

--- a/recipes-netflix/netflix/netflix_6.1.%.bbappend
+++ b/recipes-netflix/netflix/netflix_6.1.%.bbappend
@@ -1,0 +1,6 @@
+# Example how to cherry-picks unmerged changes from RDK gerrit and use them in our CI.
+# The following example fetches the code from:
+# https://code.rdkcentral.com/r/c/apps/netflix/netflix-6.1/+/79896/8
+inherit codecentral_cherry_picking
+CODECENTRAL_CHERRY_PICKS += "85607/revisions/439980100bc5e74b5b91a5444c4d0c2902a3c8f7 import-sources.patch;patchdir=${S}/../../../git/"
+


### PR DESCRIPTION
add netflix bbappend & cherry-pick OMWAPPI-1819 fix: 
"importFromPersisted & exportToPersisted used
'algorithm' and 'usage' fields in different order"