### PR TITLE
ONEM-31415: backport generator fix provided by Metrological from master branch

### DIFF
--- a/recipes-thunder/thunder-tools-4.3.0/0001-JsonGenerator-Fix-buffer-passing-when-buffer-is-outp.patch
+++ b/recipes-thunder/thunder-tools-4.3.0/0001-JsonGenerator-Fix-buffer-passing-when-buffer-is-outp.patch
@@ -1,0 +1,29 @@
+From de8f53faf694e07b9cc50b94dc8e63aef85c2501 Mon Sep 17 00:00:00 2001
+From: sebaszm <45654185+sebaszm@users.noreply.github.com>
+Date: Fri, 7 Jul 2023 10:57:11 +0200
+Subject: [PATCH] [JsonGenerator] Fix buffer passing when buffer is output only
+ (#28)
+
+---
+ JsonGenerator/source/rpc_emitter.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/JsonGenerator/source/rpc_emitter.py b/JsonGenerator/source/rpc_emitter.py
+index cc9df5d..c87faeb 100644
+--- a/JsonGenerator/source/rpc_emitter.py
++++ b/JsonGenerator/source/rpc_emitter.py
+@@ -415,9 +415,9 @@ def _EmitRpcCode(root, emit, header_file, source_file, data_emitted):
+                     if isinstance(arg, JsonString) and "length" in arg.flags:
+                         length = arg.flags.get("length")
+ 
+-                        for name, [var, _] in vars.items():
++                        for name, [var, var_type] in vars.items():
+                             if name == length.local_name:
+-                                initializer = (parent + var.cpp_name) if is_readable else ""
++                                initializer = (parent + var.cpp_name) if "r" in var_type else ""
+                                 emit.Line("%s %s{%s};" % (var.cpp_native_type, var.TempName(), initializer))
+                                 break
+ 
+-- 
+2.25.1
+

--- a/recipes-thunder/thunder-tools-native_4.3.0.bb
+++ b/recipes-thunder/thunder-tools-native_4.3.0.bb
@@ -8,6 +8,8 @@ SRC_URI = "git://github.com/rdkcentral/ThunderTools.git;protocol=https;branch=R4
 SRCREV_thundertools="13a2c71dec3cfab814a41b6a86dd8ea09ee17698"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c3349dc67b2f8c28fc99b300eb39e3cc"
 
+SRC_URI += "file://0001-JsonGenerator-Fix-buffer-passing-when-buffer-is-outp.patch"
+
 PROVIDES += "wpeframework-tools-native"
 
 inherit cmake pkgconfig native python3native


### PR DESCRIPTION
Source: https://github.com/rdkcentral/ThunderTools/pull/28

Testing build: https://jenkins.onemw.net/job/EngineeringBuild/22542/ (extra inject: https://gerrit.onemw.net/c/onemw-manifests/+/109060/3/)