### PR TITLE
ONEM-31421 icrypto buffers size back to 32 bit

### DIFF
--- a/recipes-thunder-lgi/thunderclientlibraries/cryptography-tcl-4.3.0/0105-iCrypto-nexus-platform-vault-tests.patch
+++ b/recipes-thunder-lgi/thunderclientlibraries/cryptography-tcl-4.3.0/0105-iCrypto-nexus-platform-vault-tests.patch
@@ -14,7 +14,7 @@ Index: git/Source/cryptography/tests/cryptography_test/CMakeLists.txt
 ===================================================================
 --- git.orig/Source/cryptography/tests/cryptography_test/CMakeLists.txt
 +++ git/Source/cryptography/tests/cryptography_test/CMakeLists.txt
-@@ -134,3 +134,31 @@ target_link_libraries(cobalttests
+@@ -139,3 +139,31 @@ target_link_libraries(cobalttests
      )
  
  install(TARGETS cobalttests DESTINATION bin)
@@ -91,7 +91,7 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +        printf(">\n");                                                    \
 +    }
 +
-+void DumpBufferEx(const char *desc, const uint8_t buf[], const uint16_t size, size_t pos = 0, bool doprint = true)
++void DumpBufferEx(const char *desc, const uint8_t buf[], const uint32_t size, size_t pos = 0, bool doprint = true)
 +{
 +    printf("%s:", desc);
 +    DumpBuffer(buf + pos, size);
@@ -129,9 +129,9 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +
 +void testaes(WPEFramework::Cryptography::ICipher *aes, const uint8_t *data)
 +{
-+    const uint16_t dataSize = strlen(reinterpret_cast<const char *>(data));
-+    const uint16_t expectedSize = dataSize + (16 - (dataSize % 16));
-+    const uint16_t bufferSize = expectedSize + 16;
++    const uint32_t dataSize = strlen(reinterpret_cast<const char *>(data));
++    const uint32_t expectedSize = dataSize + (16 - (dataSize % 16));
++    const uint32_t bufferSize = expectedSize + 16;
 +
 +    // const uint8_t iv[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
 +    const uint8_t *iv = reinterpret_cast<const uint8_t *>("oijasdoijasodijasodijaosidjaosidjaoisdjaoisvweertertsdfsdf");
@@ -314,7 +314,7 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +    EXPECT_EQ(key_id, 0);
 +}
 +
-+void aesSpeedTest(const uint16_t sz)
++void aesSpeedTest(const uint32_t sz)
 +{
 +    WPEFramework::Cryptography::IVault *vault = cg->Vault(cryptographyvault::CRYPTOGRAPHY_VAULT_PLATFORM);
 +    EXPECT_NE(vault, nullptr);
@@ -331,9 +331,9 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +    WPEFramework::Cryptography::ICipher *aes = vault->AES(WPEFramework::Cryptography::aesmode::CBC, key_id);
 +    EXPECT_NE(aes, nullptr);
 +
-+    const uint16_t dataSize = sz;
-+    const uint16_t expectedSize = dataSize + (16 - (dataSize % 16));
-+    const uint16_t bufferSize = expectedSize + 16;
++    const uint32_t dataSize = sz;
++    const uint32_t expectedSize = dataSize + (16 - (dataSize % 16));
++    const uint32_t bufferSize = expectedSize + 16;
 +
 +    const uint8_t iv[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
 +
@@ -397,8 +397,8 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +TEST(Platform, SpeedTest)
 +{
 +    aesSpeedTest(128);
-+    aesSpeedTest(12800);
-+    aesSpeedTest(65535 - 32);
++    aesSpeedTest(1024 * 1024);
++    aesSpeedTest(256 * 1024 * 1024);
 +}
 +
 +TEST(Platform, TwoVaults)
@@ -477,9 +477,9 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +
 +    const char *data = "Mon aéroglisseur est rempli d'anguilles";
 +
-+    const uint16_t dataSize = strlen(data);
-+    const uint16_t expectedSize = dataSize + (16 - (dataSize % 16));
-+    const uint16_t bufferSize = expectedSize + 16;
++    const uint32_t dataSize = strlen(data);
++    const uint32_t expectedSize = dataSize + (16 - (dataSize % 16));
++    const uint32_t bufferSize = expectedSize + 16;
 +
 +    const uint8_t iv[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
 +
@@ -544,9 +544,9 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +    char *data = new char[16 * 3 + 1];
 +    sprintf(data, "0123456789abcdef0123456789abcdef0123456789abcdef");
 +
-+    const uint16_t dataSize = strlen(data);
-+    const uint16_t expectedSize = dataSize + (16 - (dataSize % 16));
-+    const uint16_t bufferSize = expectedSize + 16;
++    const uint32_t dataSize = strlen(data);
++    const uint32_t expectedSize = dataSize + (16 - (dataSize % 16));
++    const uint32_t bufferSize = expectedSize + 16;
 +
 +    const uint8_t iv[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
 +                          0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
@@ -579,7 +579,7 @@ Index: git/Source/cryptography/tests/cryptography_test/LgiPlatformInterfaceTests
 +        CALL(Platform, TwoVaults);
 +        CALL(Platform, SeveralKeys);
 +        CALL(Platform, TestAESCBC);
-+	cg->Release();
++        cg->Release();
 +    }
 +    else
 +    {

--- a/recipes-thunder/thunderclientlibraries/cryptography-tcl-4.3.0/0006-ONEM-31421-Revert-the-uint32_t-uint16_t-on-IHash-and-ICryptogra.patch
+++ b/recipes-thunder/thunderclientlibraries/cryptography-tcl-4.3.0/0006-ONEM-31421-Revert-the-uint32_t-uint16_t-on-IHash-and-ICryptogra.patch
@@ -1,0 +1,114 @@
+change taken from upstream: 
+https://github.com/rdkcentral/ThunderClientLibraries/commit/62fe8d04cae2b94c0c2c9fc21ed4d3edf25b222d
+
+From 4467e1013bee127052b95ab8b99e50650d016dcc Mon Sep 17 00:00:00 2001
+From: HaseenaSainul <41037131+HaseenaSainul@users.noreply.github.com>
+Date: Wed, 5 Jul 2023 20:17:45 +0530
+Subject: [PATCH] Revert the uint32_t -> uint16_t on IHash and ICryptography
+ (#211)
+
+---
+ Source/cryptography/Cryptography.cpp          | 26 +++++++++----------
+ Source/cryptography/ICryptography.h           | 10 +++----
+
+Index: git/Source/cryptography/Cryptography.cpp
+===================================================================
+--- git.orig/Source/cryptography/Cryptography.cpp
++++ git/Source/cryptography/Cryptography.cpp
+@@ -160,16 +160,16 @@ namespace Implementation {
+ 
+     public:
+         int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+-            const uint16_t inputLength, const uint8_t input[],
+-            const uint16_t maxOutputLength, uint8_t output[]) const override
++            const uint32_t inputLength, const uint8_t input[],
++            const uint32_t maxOutputLength, uint8_t output[]) const override
+         {
+             Core::SafeSyncType<Core::CriticalSection> lock(_adminLock);
+             return (_accessor != nullptr) ? _accessor->Encrypt(ivLength, iv, inputLength, input, maxOutputLength, output) : 0;
+         }
+ 
+         int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+-            const uint16_t inputLength, const uint8_t input[],
+-            const uint16_t maxOutputLength, uint8_t output[]) const override
++            const uint32_t inputLength, const uint8_t input[],
++            const uint32_t maxOutputLength, uint8_t output[]) const override
+         {
+             Core::SafeSyncType<Core::CriticalSection> lock(_adminLock);
+             return (_accessor != nullptr) ? _accessor->Decrypt(ivLength, iv, inputLength, input, maxOutputLength, output) : 0;
+@@ -206,7 +206,7 @@ namespace Implementation {
+ 
+     public:
+         /* Ingest data into the hash calculator (multiple calls possible) */
+-        uint32_t Ingest(const uint16_t length, const uint8_t data[] /* @length:length */) override
++        uint32_t Ingest(const uint32_t length, const uint8_t data[] /* @length:length */) override
+         {
+             Core::SafeSyncType<Core::CriticalSection> lock(_adminLock);
+             return (_accessor != nullptr ? _accessor->Ingest(length, data) : 0);
+@@ -504,9 +504,9 @@ namespace Implementation {
+         }
+ 
+     public:
+-        uint32_t Ingest(const uint16_t length, const uint8_t data[]) override
++        uint32_t Ingest(const uint32_t length, const uint8_t data[]) override
+         {
+-            return (hash_ingest(_implementation, static_cast<uint32_t>(length), data));
++            return (hash_ingest(_implementation, length, data));
+         }
+ 
+         uint8_t Calculate(const uint8_t maxLength, uint8_t data[]) override
+@@ -644,17 +644,17 @@ namespace Implementation {
+ 
+         public:
+             int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+-                const uint16_t inputLength, const uint8_t input[],
+-                const uint16_t maxOutputLength, uint8_t output[]) const override
++                const uint32_t inputLength, const uint8_t input[],
++                const uint32_t maxOutputLength, uint8_t output[]) const override
+             {
+-                return (cipher_encrypt(_implementation, ivLength, iv, static_cast<uint32_t>(inputLength), input, static_cast<uint32_t>(maxOutputLength), output));
++                return (cipher_encrypt(_implementation, ivLength, iv, inputLength, input, maxOutputLength, output));
+             }
+ 
+             int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+-                const uint16_t inputLength, const uint8_t input[],
+-                const uint16_t maxOutputLength, uint8_t output[]) const override
++                const uint32_t inputLength, const uint8_t input[],
++                const uint32_t maxOutputLength, uint8_t output[]) const override
+             {
+-                return (cipher_decrypt(_implementation, ivLength, iv, static_cast<uint32_t>(inputLength), input, static_cast<uint32_t>(maxOutputLength), output));
++                return (cipher_decrypt(_implementation, ivLength, iv, inputLength, input, maxOutputLength, output));
+             }
+ 
+         public:
+Index: git/Source/cryptography/ICryptography.h
+===================================================================
+--- git.orig/Source/cryptography/ICryptography.h
++++ git/Source/cryptography/ICryptography.h
+@@ -65,7 +65,7 @@ namespace Cryptography {
+         ~IHash() override = default;
+ 
+         /* Ingest data into the hash calculator (multiple calls possible) */
+-        virtual uint32_t Ingest(const uint16_t length, const uint8_t data[] /* @in @length:length */) = 0;
++        virtual uint32_t Ingest(const uint32_t length, const uint8_t data[] /* @in @length:length */) = 0;
+ 
+         /* Calculate the hash from all ingested data */
+         virtual uint8_t Calculate(const uint8_t maxLength, uint8_t data[] /* @out @maxlength:maxLength */) = 0;
+@@ -83,13 +83,13 @@ namespace Cryptography {
+ 
+         /* Encrypt data */
+         virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[] /* @in @length:ivLength */,
+-                                const uint16_t inputLength, const uint8_t input[] /* @in @length:inputLength */,
+-                                const uint16_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
++                                const uint32_t inputLength, const uint8_t input[] /* @in @length:inputLength */,
++                                const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
+ 
+         /* Decrypt data */
+         virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[] /* @in @length:ivLength */,
+-                                const uint16_t inputLength, const uint8_t input[] /* @in @length:inputLength */,
+-                                const uint16_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
++                                const uint32_t inputLength, const uint8_t input[] /* @in @length:inputLength */,
++                                const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
+     };
+ 
+     struct EXTERNAL IDiffieHellman : virtual public Core::IUnknown {

--- a/recipes-thunder/thunderclientlibraries/cryptography-tcl_4.3.0.bb
+++ b/recipes-thunder/thunderclientlibraries/cryptography-tcl_4.3.0.bb
@@ -6,6 +6,7 @@ require include/thunder_clientlibraries_${PV}.inc
 
 SRC_URI += "file://0004-Cipher-CipherNetflix-methods-return-type-changes.patch \
             file://R4.1_Trace_enabled_error_wpeframework_clientlibraries.patch \
+            file://0006-ONEM-31421-Revert-the-uint32_t-uint16_t-on-IHash-and-ICryptogra.patch \
            "
 #Cryptography library 
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'enable_icrypto_openssl','openssl', 'virtual/secapi', d)}"


### PR DESCRIPTION
applying upstream fix:

https://github.com/rdkcentral/ThunderClientLibraries/commit/62fe8d04cae2b94c0c2c9fc21ed4d3edf25b222d

and relevant changes to the tests